### PR TITLE
Coveralls -> codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
     - 3.6
     - pypy3.5-5.8.0
 install:
-    - travis_retry pip install coveralls flake8
+    - travis_retry pip install codecov flake8
 before_script:
     - flake8 aioftp
 script:
@@ -13,4 +13,4 @@ branches:
     only:
         - master
 after_success:
-    coveralls
+    codecov

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ aioftp
 .. image:: https://img.shields.io/travis/aio-libs/aioftp.svg
     :target: https://travis-ci.org/aio-libs/aioftp
 
-.. image:: https://img.shields.io/coveralls/aio-libs/aioftp.svg
-    :target: https://coveralls.io/github/aio-libs/aioftp
+.. image:: https://codecov.io/gh/aio-libs/aioftp/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/aio-libs/aioftp
 
 .. image:: https://img.shields.io/pypi/v/aioftp.svg
     :target: https://pypi.python.org/pypi/aioftp


### PR DESCRIPTION
Let's switch from coveralls to codecov for sake of unification with other aio-libs projects.

Also codecov has a fancy **officially supported** [browser extension](https://docs.codecov.io/v4.3.6/docs/browser-extension).