### PR TITLE
Resolve ipv6 error

### DIFF
--- a/aioftp/server.py
+++ b/aioftp/server.py
@@ -832,7 +832,7 @@ class Server(AbstractServer):
         self.encoding = encoding
 
     async def dispatcher(self, reader, writer):
-        host, port = writer.transport.get_extra_info("peername", ("", ""))
+        host, port, *_ = writer.transport.get_extra_info("peername", ("", ""))
         current_server_host, *_ = writer.transport.get_extra_info("sockname")
         logger.info("new connection from %s:%s", host, port)
         key = stream = ThrottleStreamIO(


### PR DESCRIPTION
Discard additional values from unpacking an ipv6 tuple.

Closes #63.