### PR TITLE
Move PathIO creation to connection

### DIFF
--- a/aioftp/pathio.py
+++ b/aioftp/pathio.py
@@ -93,10 +93,14 @@ class AbstractPathIO:
 
     :param loop: loop to use
     :type loop: :py:class:`asyncio.BaseEventLoop`
+
+    :param connection: server connection that is accessing this PathIO
+    :type connection: :py:class:`aioftp.Connection`
     """
-    def __init__(self, timeout=None, loop=None):
+    def __init__(self, timeout=None, loop=None, connection=None):
         self.timeout = timeout
         self.loop = loop or asyncio.get_event_loop()
+        self.connection = connection
 
     @universal_exception
     async def exists(self, path):


### PR DESCRIPTION
Instead of a `Connection` object being passed a pointer to the main `PathIO` object it is passed the `PathIO` factory class which allows it to create it's own `PathIO` instance.

This allows the `Connection` to pass itself to the `PathIO` instance and allows all `PathIO` methods to access the `connection` object. 

This is useful if the IO operations need to know the username or password in order to function. For example for calling a third-party API and passing the credentials along.

Closes #66.