### PR TITLE
fix `__aiter__` must be plain function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
     - 3.5
     - 3.6
+    - 3.7
 install:
     - travis_retry pip install codecov flake8
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: python
 python:
     - 3.5
     - 3.6
-    - 3.7
+jobs:
+    include:
+        - python: 3.7
+          dist: xenial
+          sudo: required
 install:
     - travis_retry pip install codecov flake8
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+version: = 0
+conditions: v1
+
 language: python
 python:
     - 3.5

--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -628,6 +628,7 @@ class Client(BaseClient):
             >>> stats = await client.list()
         """
         class AsyncLister(AsyncListerMixin):
+            stream = None
 
             async def _new_stream(cls, local_path):
                 cls.path = local_path
@@ -642,12 +643,16 @@ class Client(BaseClient):
                 command = ("LIST " + str(cls.path)).strip()
                 return await self.get_stream(command, "1xx")
 
-            async def __aiter__(cls):
-                cls.stream = await cls._new_stream(path)
+            def __aiter__(cls):
                 cls.directories = collections.deque()
                 return cls
 
             async def __anext__(cls):
+                if cls.stream is None:
+                    cls.stream = await cls._new_stream(path)
+                    # this was previously in __aiter__ however as __aiter__ is
+                    # now synchronous only (py 3.7) this is the workaround.
+
                 while True:
                     line = await cls.stream.readline()
                     while not line:

--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -650,9 +650,6 @@ class Client(BaseClient):
             async def __anext__(cls):
                 if cls.stream is None:
                     cls.stream = await cls._new_stream(path)
-                    # this was previously in __aiter__ however as __aiter__ is
-                    # now synchronous only (py 3.7) this is the workaround.
-
                 while True:
                     line = await cls.stream.readline()
                     while not line:

--- a/aioftp/common.py
+++ b/aioftp/common.py
@@ -94,7 +94,7 @@ class AsyncStreamIterator:
     def __init__(self, read_coro):
         self.read_coro = read_coro
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):
@@ -142,7 +142,7 @@ class AbstractAsyncLister(AsyncListerMixin):
         >>> class Lister(AbstractAsyncLister):
         ...
         ...     @with_timeout
-        ...     async def __aiter__(self):
+        ...     def __aiter__(self):
         ...         ...
 
         ...     @with_timeout
@@ -165,7 +165,7 @@ class AbstractAsyncLister(AsyncListerMixin):
         self.loop = loop or asyncio.get_event_loop()
 
     @with_timeout
-    async def __aiter__(self):
+    def __aiter__(self):
         raise NotImplementedError
 
     @with_timeout

--- a/aioftp/common.py
+++ b/aioftp/common.py
@@ -131,7 +131,7 @@ class AbstractAsyncLister(AsyncListerMixin):
     :py:class:`list` via `await` with optional timeout (via
     :py:func:`aioftp.with_timeout`)
 
-    :param timeout: timeout for __aiter__, __anext__ operations
+    :param timeout: timeout for __anext__ operation
     :type timeout: :py:class:`None`, :py:class:`int` or :py:class:`float`
 
     :param loop: loop to use for timeouts
@@ -141,10 +141,6 @@ class AbstractAsyncLister(AsyncListerMixin):
 
         >>> class Lister(AbstractAsyncLister):
         ...
-        ...     @with_timeout
-        ...     def __aiter__(self):
-        ...         ...
-
         ...     @with_timeout
         ...     async def __anext__(self):
         ...         ...
@@ -164,9 +160,8 @@ class AbstractAsyncLister(AsyncListerMixin):
         self.timeout = timeout
         self.loop = loop or asyncio.get_event_loop()
 
-    @with_timeout
     def __aiter__(self):
-        raise NotImplementedError
+        return self
 
     @with_timeout
     async def __anext__(self):

--- a/aioftp/pathio.py
+++ b/aioftp/pathio.py
@@ -462,7 +462,7 @@ class AsyncPathIO(AbstractPathIO):
 
             @universal_exception
             @with_timeout
-            async def __aiter__(self):
+            def __aiter__(self):
                 return self
 
             @universal_exception

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     url="https://github.com/aio-libs/aioftp",
     license="Apache 2",
     packages=find_packages(),
-    python_requires=" >= 3.5.0",
+    python_requires=" >= 3.5.3",
     install_requires=[],
     tests_require=["nose", "coverage"],
     cmdclass={"test": NoseTestCommand},

--- a/tests/test-abort.py
+++ b/tests/test-abort.py
@@ -67,18 +67,12 @@ class FakeSlowPathIO(aioftp.PathIO):
         return b"-" * 8192
 
     def list(self, path):
-
         # infinite list
         files = tuple(path.glob("*"))
 
         class Lister(aioftp.AbstractAsyncLister):
 
-            def __aiter__(self):
-
-                return self
-
             async def __anext__(self):
-
                 return files[0]
 
         return Lister(timeout=self.timeout, loop=self.loop)

--- a/tests/test-abort.py
+++ b/tests/test-abort.py
@@ -73,7 +73,7 @@ class FakeSlowPathIO(aioftp.PathIO):
 
         class Lister(aioftp.AbstractAsyncLister):
 
-            async def __aiter__(self):
+            def __aiter__(self):
 
                 return self
 

--- a/tests/test-connection.py
+++ b/tests/test-connection.py
@@ -41,9 +41,7 @@ async def test_not_implemented(loop, client, server):
 
 @aioftp_setup()
 @with_connection
-@expect_codes_in_exception("502")
-async def test_type_not_implemented(loop, client, server):
-
+async def test_type_success(loop, client, server):
     await client.login()
     await client.get_passive_connection("A")
 

--- a/tests/test-directory-actions.py
+++ b/tests/test-directory-actions.py
@@ -166,7 +166,7 @@ class FakeErrorPathIO(aioftp.PathIO):
 
             @aioftp.pathio.universal_exception
             @aioftp.with_timeout
-            async def __aiter__(self):
+            def __aiter__(self):
 
                 self.iter = path.glob("*")
                 return self

--- a/tests/test-directory-actions.py
+++ b/tests/test-directory-actions.py
@@ -163,24 +163,16 @@ class FakeErrorPathIO(aioftp.PathIO):
     def list(self, path):
 
         class Lister(aioftp.AbstractAsyncLister):
-
-            @aioftp.pathio.universal_exception
-            @aioftp.with_timeout
-            def __aiter__(self):
-
-                self.iter = path.glob("*")
-                return self
+            iter = None
 
             @aioftp.pathio.universal_exception
             @aioftp.with_timeout
             async def __anext__(self):
-
+                if self.iter is None:
+                    self.iter = path.glob("*")
                 try:
-
                     raise Exception("KERNEL PANIC")
-
                 except StopIteration:
-
                     raise StopAsyncIteration
 
         return Lister(timeout=self.timeout, loop=self.loop)


### PR DESCRIPTION
This adds support for Python 3.7 for async generators. That is, 
```py
async def __aiter__(self):
``` 
is not supported in Python 3.7. However, 
```py
def __aiter__(self):
```
is supported in all supported versions of this library.

This also bumps the travis build version.

In instances such as [this](https://github.com/Modelmat/aioftp/blob/3_7_update/aioftp/pathio.py#L452-L476) and [this](https://github.com/Modelmat/aioftp/blob/3_7_update/aioftp/client.py#L601-L679) a workaround has been used to support await statements that were previously in `__aiter__` however this decreases performance.
