### PR TITLE
Fix deprecation warning in Python 3.7

### DIFF
--- a/aioftp/server.py
+++ b/aioftp/server.py
@@ -8,6 +8,7 @@ import collections
 import enum
 import logging
 import stat
+import sys
 
 from . import errors
 from . import pathio
@@ -35,6 +36,13 @@ __all__ = (
     "AbstractServer",
     "Server",
 )
+
+IS_PY37_PLUS = sys.version_info[:2] >= (3, 7)
+if IS_PY37_PLUS:
+    get_current_task = asyncio.current_task
+else:
+    get_current_task = asyncio.Task.current_task
+
 logger = logging.getLogger(__name__)
 
 
@@ -875,7 +883,7 @@ class Server(AbstractServer):
             response=lambda *args: response_queue.put_nowait(args),
             acquired=False,
             restart_offset=0,
-            _dispatcher=asyncio.Task.current_task(loop=self.loop),
+            _dispatcher=get_current_task(loop=self.loop),
         )
         connection.path_io = self.path_io_factory(timeout=self.path_timeout,
                                                   loop=self.loop,


### PR DESCRIPTION
This fixes the warning:

> ... server.py:878: PendingDeprecationWarning: Task.current_task() is
> deprecated, use asyncio.current_task() instead

as documented at https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.current_task:

> This method is deprecated and will be removed in Python 3.9. Use the
> asyncio.current_task() function instead.

The function `asyncio.current_task()` was only added in Python 3.7, and we're supporting earlier, hence the check on Python version.