### PR TITLE
Rename 'pass_' to 'pass' in `commands_mapping` and remove special case

### DIFF
--- a/aioftp/server.py
+++ b/aioftp/server.py
@@ -842,7 +842,7 @@ class Server(AbstractServer):
             "mkd": self.mkd,
             "mlsd": self.mlsd,
             "mlst": self.mlst,
-            "pass_": self.pass_,
+            "pass": self.pass_,
             "pasv": self.pasv,
             "pbsz": self.pbsz,
             "prot": self.prot,
@@ -923,9 +923,6 @@ class Server(AbstractServer):
                     elif isinstance(result, tuple):
                         pending.add(self.parse_command(stream))
                         cmd, rest = result
-                        if cmd == "pass":
-                            # is there a better solution?
-                            cmd = "pass_"
                         f = self.commands_mapping.get(cmd)
                         if f is not None:
                             pending.add(f(connection, rest))

--- a/history.rst
+++ b/history.rst
@@ -1,3 +1,9 @@
+x.x.x (xx-xx-xxxx)
+------------------
+
+- server: remove obsolete `pass` to `pass_` command renaming
+Thanks to `Puddly <https://github.com/puddly>`_
+
 0.15.0 (07-01-2019)
 -------------------
 


### PR DESCRIPTION
This is a small change to make `commands_mapping` perform all translation, removing the additional code that renamed `pass` to `pass_`.

Code utilizing `self.commands_mapping['pass_']` explicitly will break.