### PR TITLE
Fix leap year (fixes #107 #109)

### DIFF
--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -355,7 +355,8 @@ class BaseClient:
         """
         return d.strftime("%Y%m%d%H%M00")
 
-    def parse_ls_date(self, s, *, now=None):
+    @classmethod
+    def parse_ls_date(cls, s, *, now=None):
         """
         Parsing dates from the ls unix utility. For example,
         "Nov 18  1958" and "Nov 18 12:29".
@@ -387,7 +388,7 @@ class BaseClient:
                         d = d.replace(year=now.year - 1)
             except ValueError:
                 d = datetime.datetime.strptime(s, "%b %d  %Y")
-        return self.format_date_time(d)
+        return cls.format_date_time(d)
 
     def parse_list_line_unix(self, b):
         """

--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -27,6 +27,7 @@ from .common import (
     async_enterable,
     setlocale,
     HALF_OF_YEAR_IN_SECONDS,
+    TWO_YEARS_IN_SECONDS,
 )
 
 __all__ = (
@@ -371,13 +372,17 @@ class BaseClient:
                 if now is None:
                     now = datetime.datetime.now()
                 if s.startswith('Feb 29'):
-                    # Need to find the nearest leap year
-                    year = now.year
-                    while not calendar.isleap(year):
-                        year -= 1
+                    # Need to find the nearest previous leap year
+                    prev_leap_year = now.year
+                    while not calendar.isleap(prev_leap_year):
+                        prev_leap_year -= 1
                     d = datetime.datetime.strptime(
-                        f'{year} {s}', "%Y %b %d %H:%M"
+                        f"{prev_leap_year} {s}", "%Y %b %d %H:%M"
                     )
+                    # Check if it's next leap year
+                    diff = (now - d).total_seconds()
+                    if diff > TWO_YEARS_IN_SECONDS:
+                        d = d.replace(year=prev_leap_year + 4)
                 else:
                     d = datetime.datetime.strptime(s, "%b %d %H:%M")
                     d = d.replace(year=now.year)

--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -1,4 +1,5 @@
 import re
+import calendar
 import collections
 import pathlib
 import logging
@@ -368,13 +369,22 @@ class BaseClient:
             try:
                 if now is None:
                     now = datetime.datetime.now()
-                d = datetime.datetime.strptime(s, "%b %d %H:%M")
-                d = d.replace(year=now.year)
-                diff = (now - d).total_seconds()
-                if diff > HALF_OF_YEAR_IN_SECONDS:
-                    d = d.replace(year=now.year + 1)
-                elif diff < -HALF_OF_YEAR_IN_SECONDS:
-                    d = d.replace(year=now.year - 1)
+                if s.startswith('Feb 29'):
+                    # Need to find the nearest leap year
+                    year = now.year
+                    while not calendar.isleap(year):
+                        year -= 1
+                    d = datetime.datetime.strptime(
+                        f'{year} {s}', "%Y %b %d %H:%M"
+                    )
+                else:
+                    d = datetime.datetime.strptime(s, "%b %d %H:%M")
+                    d = d.replace(year=now.year)
+                    diff = (now - d).total_seconds()
+                    if diff > HALF_OF_YEAR_IN_SECONDS:
+                        d = d.replace(year=now.year + 1)
+                    elif diff < -HALF_OF_YEAR_IN_SECONDS:
+                        d = d.replace(year=now.year - 1)
             except ValueError:
                 d = datetime.datetime.strptime(s, "%b %d  %Y")
         return self.format_date_time(d)

--- a/aioftp/common.py
+++ b/aioftp/common.py
@@ -36,6 +36,7 @@ DEFAULT_USER = "anonymous"
 DEFAULT_PASSWORD = "anon@"
 DEFAULT_ACCOUNT = ""
 HALF_OF_YEAR_IN_SECONDS = 15778476
+TWO_YEARS_IN_SECONDS = ((365 * 3 + 366) * 24 * 60 * 60) / 2
 
 
 def _now():

--- a/aioftp/errors.py
+++ b/aioftp/errors.py
@@ -2,13 +2,21 @@ from . import common
 
 
 __all__ = (
+    "AIOFTPException",
     "StatusCodeError",
     "PathIsNotAbsolute",
     "PathIOError",
+    "NoAvailablePort",
 )
 
 
-class StatusCodeError(Exception):
+class AIOFTPException(Exception):
+    """
+    Base exception class.
+    """
+
+
+class StatusCodeError(AIOFTPException):
     """
     Raised for unexpected or "bad" status codes.
 
@@ -41,13 +49,13 @@ class StatusCodeError(Exception):
         self.info = info
 
 
-class PathIsNotAbsolute(Exception):
+class PathIsNotAbsolute(AIOFTPException):
     """
     Raised when "path" is not absolute.
     """
 
 
-class PathIOError(Exception):
+class PathIOError(AIOFTPException):
     """
     Universal exception for any path io errors.
 
@@ -67,7 +75,7 @@ class PathIOError(Exception):
         self.reason = reason
 
 
-class NoAvailablePort(OSError):
+class NoAvailablePort(AIOFTPException, OSError):
     """
     Raised when there is no available data port
     """

--- a/history.rst
+++ b/history.rst
@@ -4,6 +4,10 @@ x.x.x (xx-xx-xxxx)
 - server: remove obsolete `pass` to `pass_` command renaming
 Thanks to `Puddly <https://github.com/puddly>`_
 
+- client: fix leap year bug at `parse_ls_date` method
+- all: add base exception class
+Thanks to `decaz <https://github.com/decaz>`_
+
 0.15.0 (07-01-2019)
 -------------------
 

--- a/tests/test_simple_functions.py
+++ b/tests/test_simple_functions.py
@@ -61,7 +61,15 @@ def _c_locale_time(d, format="%b %d %H:%M"):
         return d.strftime(format)
 
 
-def test_parse_list_datetime_not_older_than_6_month_format():
+def test_parse_ls_date_of_leap_year():
+    def date_to_p(d):
+        return d.strftime("%Y%m%d%H%M00")
+    p = aioftp.Client.parse_ls_date
+    d = datetime.datetime(year=2020, month=2, day=29)
+    assert p(aioftp.Client, _c_locale_time(d)) == date_to_p(d)
+
+
+def test_parse_ls_date_not_older_than_6_month_format():
     def date_to_p(d):
         return d.strftime("%Y%m%d%H%M00")
     p = aioftp.Client.parse_ls_date
@@ -76,7 +84,7 @@ def test_parse_list_datetime_not_older_than_6_month_format():
         assert p(aioftp.Client, _c_locale_time(d), now=now) == date_to_p(d)
 
 
-def test_parse_list_datetime_older_than_6_month_format():
+def test_parse_ls_date_older_than_6_month_format():
     def date_to_p(d):
         return d.strftime("%Y%m%d%H%M00")
     p = aioftp.Client.parse_ls_date
@@ -95,7 +103,7 @@ def test_parse_list_datetime_older_than_6_month_format():
         assert p(aioftp.Client, _c_locale_time(d), now=now) == expect
 
 
-def test_parse_list_datetime_short():
+def test_parse_ls_date_short():
     def date_to_p(d):
         return d.strftime("%Y%m%d%H%M00")
     p = aioftp.Client.parse_ls_date

--- a/tests/test_simple_functions.py
+++ b/tests/test_simple_functions.py
@@ -66,7 +66,7 @@ def test_parse_ls_date_of_leap_year():
         return d.strftime("%Y%m%d%H%M00")
     p = aioftp.Client.parse_ls_date
     d = datetime.datetime(year=2020, month=2, day=29)
-    assert p(aioftp.Client, _c_locale_time(d)) == date_to_p(d)
+    assert p(_c_locale_time(d)) == date_to_p(d)
 
 
 def test_parse_ls_date_not_older_than_6_month_format():
@@ -81,7 +81,7 @@ def test_parse_ls_date_not_older_than_6_month_format():
     deltas = (datetime.timedelta(), dt, -dt)
     for now, delta in itertools.product(dates, deltas):
         d = now + delta
-        assert p(aioftp.Client, _c_locale_time(d), now=now) == date_to_p(d)
+        assert p(_c_locale_time(d), now=now) == date_to_p(d)
 
 
 def test_parse_ls_date_older_than_6_month_format():
@@ -100,7 +100,7 @@ def test_parse_ls_date_older_than_6_month_format():
             expect = date_to_p(d.replace(year=d.year - 1))
         else:
             expect = date_to_p(d.replace(year=d.year + 1))
-        assert p(aioftp.Client, _c_locale_time(d), now=now) == expect
+        assert p(_c_locale_time(d), now=now) == expect
 
 
 def test_parse_ls_date_short():
@@ -113,7 +113,7 @@ def test_parse_ls_date_short():
     )
     for d in dates:
         s = _c_locale_time(d, format="%b %d  %Y")
-        assert p(aioftp.Client, s) == date_to_p(d)
+        assert p(s) == date_to_p(d)
 
 
 def test_parse_list_line_unix():

--- a/tests/test_simple_functions.py
+++ b/tests/test_simple_functions.py
@@ -65,8 +65,49 @@ def test_parse_ls_date_of_leap_year():
     def date_to_p(d):
         return d.strftime("%Y%m%d%H%M00")
     p = aioftp.Client.parse_ls_date
-    d = datetime.datetime(year=2020, month=2, day=29)
-    assert p(_c_locale_time(d)) == date_to_p(d)
+    # Leap year date to test
+    d = datetime.datetime(year=2000, month=2, day=29)
+    current_and_expected_dates = (
+        # 2016 (leap)
+        (
+            datetime.datetime(year=2016, month=2, day=29),
+            datetime.datetime(year=2016, month=2, day=29)
+        ),
+        # 2017
+        (
+            datetime.datetime(year=2017, month=2, day=28),
+            datetime.datetime(year=2016, month=2, day=29)
+        ),
+        (
+            datetime.datetime(year=2017, month=3, day=1),
+            datetime.datetime(year=2016, month=2, day=29)
+        ),
+        # 2018
+        (
+            datetime.datetime(year=2018, month=2, day=28),
+            datetime.datetime(year=2016, month=2, day=29)
+        ),
+        (
+            datetime.datetime(year=2018, month=3, day=1),
+            datetime.datetime(year=2020, month=2, day=29)
+        ),
+        # 2019
+        (
+            datetime.datetime(year=2019, month=2, day=28),
+            datetime.datetime(year=2020, month=2, day=29)
+        ),
+        (
+            datetime.datetime(year=2019, month=3, day=1),
+            datetime.datetime(year=2020, month=2, day=29)
+        ),
+        # 2020 (leap)
+        (
+            datetime.datetime(year=2020, month=2, day=29),
+            datetime.datetime(year=2020, month=2, day=29)
+        ),
+    )
+    for now, expected in current_and_expected_dates:
+        assert p(_c_locale_time(d), now=now) == date_to_p(expected)
 
 
 def test_parse_ls_date_not_older_than_6_month_format():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

- Fix leap year bug at `parse_ls_date` method
- Make `parse_ls_date` method static
- Add base exception class

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Nope.

## Related issue number

Fixes #107 #109.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
