### PR TITLE
client/server: censor the user's password when logging (fixes #111)

### DIFF
--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -232,7 +232,11 @@ class BaseClient:
         expected_codes = wrap_with_container(expected_codes)
         wait_codes = wrap_with_container(wait_codes)
         if command:
-            logger.info(command)
+            if command.startswith('PASS'):
+                # Censor the user's password
+                logger.info('PASS ' + '*' * len(command[5:]))
+            else:
+                logger.info(command)
             message = command + END_OF_LINE
             await self.stream.write(message.encode(encoding=self.encoding))
         if expected_codes or wait_codes:

--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -243,7 +243,7 @@ class BaseClient:
             if censor_after:
                 # Censor the user's command
                 logger.info(
-                    command[:censor_after] + '*' * len(command[censor_after:])
+                    command[:censor_after] + "*" * len(command[censor_after:])
                 )
             else:
                 logger.info(command)

--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -242,9 +242,9 @@ class BaseClient:
         if command:
             if censor_after:
                 # Censor the user's command
-                commands_s = command[:censor_after]
+                raw = command[:censor_after]
                 stars = "*" * len(command[censor_after:])
-                logger.info("%s %s", commands_s, stars)
+                logger.info("%s%s", raw, stars)
             else:
                 logger.info(command)
             message = command + END_OF_LINE
@@ -632,8 +632,7 @@ class Client(BaseClient):
                 cmd = "ACCT " + account
             else:
                 raise errors.StatusCodeError("33x", code, info)
-            code, info = await self.command(cmd,
-                                            ("230", "33x"),
+            code, info = await self.command(cmd, ("230", "33x"),
                                             censor_after=censor_after)
 
     async def get_current_directory(self):

--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -232,9 +232,12 @@ class BaseClient:
         expected_codes = wrap_with_container(expected_codes)
         wait_codes = wrap_with_container(wait_codes)
         if command:
-            if command.startswith('PASS'):
+            if command[:5] in {'pass ', 'PASS '}:
                 # Censor the user's password
-                logger.info('PASS ' + '*' * len(command[5:]))
+                line_end = len(command.rstrip("\r\n"))
+                logger.info(
+                    command[:5] + '*' * (line_end - 5) + command[line_end:]
+                )
             else:
                 logger.info(command)
             message = command + END_OF_LINE

--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -208,7 +208,11 @@ class BaseClient:
         if not any(map(received_code.matches, expected_codes)):
             raise errors.StatusCodeError(expected_codes, received_code, info)
 
-    async def command(self, command=None, expected_codes=(), wait_codes=()):
+    async def command(self,
+                      command=None,
+                      expected_codes=(),
+                      wait_codes=(),
+                      censor_after=None):
         """
         :py:func:`asyncio.coroutine`
 
@@ -228,15 +232,18 @@ class BaseClient:
         :param wait_codes: tuple of wait codes or wait code
         :type wait_codes: :py:class:`tuple` of :py:class:`str` or
             :py:class:`str`
+
+        :param censor_after: index after which the line should be censored
+            when logging
+        :type censor_after: :py:class:`None` or :py:class:`int`
         """
         expected_codes = wrap_with_container(expected_codes)
         wait_codes = wrap_with_container(wait_codes)
         if command:
-            if command[:5] in {'pass ', 'PASS '}:
-                # Censor the user's password
-                line_end = len(command.rstrip("\r\n"))
+            if censor_after:
+                # Censor the user's command
                 logger.info(
-                    command[:5] + '*' * (line_end - 5) + command[line_end:]
+                    command[:censor_after] + '*' * len(command[censor_after:])
                 )
             else:
                 logger.info(command)
@@ -617,13 +624,17 @@ class Client(BaseClient):
         """
         code, info = await self.command("USER " + user, ("230", "33x"))
         while code.matches("33x"):
+            censor_after = None
             if code == "331":
                 cmd = "PASS " + password
+                censor_after = 5
             elif code == "332":
                 cmd = "ACCT " + account
             else:
                 raise errors.StatusCodeError("33x", code, info)
-            code, info = await self.command(cmd, ("230", "33x"))
+            code, info = await self.command(cmd,
+                                            ("230", "33x"),
+                                            censor_after=censor_after)
 
     async def get_current_directory(self):
         """

--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -242,9 +242,9 @@ class BaseClient:
         if command:
             if censor_after:
                 # Censor the user's command
-                logger.info(
-                    command[:censor_after] + "*" * len(command[censor_after:])
-                )
+                commands_s = command[:censor_after]
+                stars = "*" * len(command[censor_after:])
+                logger.info("%s %s", commands_s, stars)
             else:
                 logger.info(command)
             message = command + END_OF_LINE

--- a/aioftp/server.py
+++ b/aioftp/server.py
@@ -481,14 +481,17 @@ class AbstractServer(abc.ABC):
                 await write(code + "-" + line)
             await write(code + " " + tail)
 
-    async def parse_command(self, stream):
+    async def parse_command(self, stream, censor_commands=('pass',)):
         """
         :py:func:`asyncio.coroutine`
 
         Complex method for getting command.
 
-        :param stream: connection steram
+        :param stream: connection stream
         :type stream: :py:class:`asyncio.StreamIO`
+
+        :param censor_commands: An optional list of commands to censor.
+        :type censor_commands: :py:class:`tuple` of :py:class:`str`
 
         :return: (code, rest)
         :rtype: (:py:class:`str`, :py:class:`str`)
@@ -497,7 +500,12 @@ class AbstractServer(abc.ABC):
         if not line:
             raise ConnectionResetError
         s = line.decode(encoding=self.encoding).rstrip()
-        logger.info(s)
+
+        if s[:4].lower() in censor_commands:
+            logger.info(s[:5] + '*' * len(s[5:]))
+        else:
+            logger.info(s)
+
         cmd, _, rest = s.partition(" ")
         return cmd.lower(), rest
 

--- a/aioftp/server.py
+++ b/aioftp/server.py
@@ -481,7 +481,7 @@ class AbstractServer(abc.ABC):
                 await write(code + "-" + line)
             await write(code + " " + tail)
 
-    async def parse_command(self, stream, censor_commands=('pass',)):
+    async def parse_command(self, stream, censor_commands=("pass",)):
         """
         :py:func:`asyncio.coroutine`
 
@@ -502,7 +502,7 @@ class AbstractServer(abc.ABC):
         s = line.decode(encoding=self.encoding).rstrip()
 
         if s[:4].lower() in censor_commands:
-            logger.info(s[:5] + '*' * len(s[5:]))
+            logger.info(s[:5] + "*" * len(s[5:]))
         else:
             logger.info(s)
 

--- a/aioftp/server.py
+++ b/aioftp/server.py
@@ -500,13 +500,14 @@ class AbstractServer(abc.ABC):
         if not line:
             raise ConnectionResetError
         s = line.decode(encoding=self.encoding).rstrip()
-
-        if s[:4].lower() in censor_commands:
-            logger.info(s[:5] + "*" * len(s[5:]))
-        else:
-            logger.info(s)
-
         cmd, _, rest = s.partition(" ")
+
+        if cmd.lower() in censor_commands:
+            stars = "*" * len(rest)
+            logger.info("%s %s", cmd, stars)
+        else:
+            logger.info("%s %s", cmd, rest)
+
         return cmd.lower(), rest
 
     async def response_writer(self, stream, response_queue):

--- a/history.rst
+++ b/history.rst
@@ -1,8 +1,8 @@
 x.x.x (xx-xx-xxxx)
 ------------------
 
-- client: strip date before parsing (#113)
-Thanks to `ndhansen <https://github.com/ndhansen>`_
+-client: logger no longer prints out plaintext password
+Thanks to `ndhansen <https://github.com/ndhansen>_`
 
 0.16.0 (11-03-2020)
 ------------------

--- a/history.rst
+++ b/history.rst
@@ -1,7 +1,8 @@
 x.x.x (xx-xx-xxxx)
 ------------------
 
--client: logger no longer prints out plaintext password
+- client: strip date before parsing (#113)
+- client: logger no longer prints out plaintext password
 Thanks to `ndhansen <https://github.com/ndhansen>_`
 
 0.16.0 (11-03-2020)

--- a/history.rst
+++ b/history.rst
@@ -3,7 +3,7 @@ x.x.x (xx-xx-xxxx)
 
 - client: strip date before parsing (#113)
 - client: logger no longer prints out plaintext password
-Thanks to `ndhansen <https://github.com/ndhansen>_`
+Thanks to `ndhansen <https://github.com/ndhansen>`_
 
 0.16.0 (11-03-2020)
 ------------------


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Currently the user's password is printed in plaintext in the logs. This PR replaces the user's password in log files with stars.

The way this is done was borrowed from https://github.com/python/cpython/blob/master/Lib/ftplib.py#L186

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Yes, they will no longer be able to see the password with which they are connecting in the log files

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#111 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
