### PR TITLE
client: allow pass-through of passive commands for directory listing

### DIFF
--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -736,7 +736,9 @@ class Client(BaseClient):
                     try:
                         command = ("MLSD " + str(cls.path)).strip()
                         return await self.get_stream(
-                            command, "1xx", passive_commands=passive_commands
+                            command,
+                            "1xx",
+                            passive_commands=passive_commands
                         )
                     except errors.StatusCodeError as e:
                         code = e.received_codes[-1]

--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -738,7 +738,7 @@ class Client(BaseClient):
                         return await self.get_stream(
                             command,
                             "1xx",
-                            passive_commands=passive_commands
+                            passive_commands=passive_commands,
                         )
                     except errors.StatusCodeError as e:
                         code = e.received_codes[-1]
@@ -748,7 +748,9 @@ class Client(BaseClient):
                     cls.parse_line = self.parse_list_line
                     command = ("LIST " + str(cls.path)).strip()
                     return await self.get_stream(
-                        command, "1xx", passive_commands=passive_commands
+                        command,
+                        "1xx",
+                        passive_commands=passive_commands,
                     )
 
             def __aiter__(cls):
@@ -1138,7 +1140,8 @@ class Client(BaseClient):
         :rtype: :py:class:`aioftp.DataConnectionThrottleStreamIO`
         """
         reader, writer = await self.get_passive_connection(
-            conn_type, commands=passive_commands
+            conn_type,
+            commands=passive_commands,
         )
         if offset:
             await self.command("REST " + str(offset), "350")

--- a/history.rst
+++ b/history.rst
@@ -2,6 +2,7 @@ x.x.x (xx-xx-xxxx)
 ------------------
 
 - client: strip date before parsing (#113)
+- client: allow pass through of passive connection commands from directory listing (#115)
 Thanks to `ndhansen <https://github.com/ndhansen>`_
 
 0.16.0 (11-03-2020)

--- a/tests/test_current_directory.py
+++ b/tests/test_current_directory.py
@@ -31,6 +31,18 @@ async def test_mlsd(pair_factory):
 
 
 @pytest.mark.asyncio
+async def test_pasv(pair_factory):
+    async with pair_factory(host="127.0.0.1") as pair:
+        await pair.make_server_files("test.txt")
+        (path, stat), *_ = files = await pair.client.list(
+            passive_commands=('pasv',)
+        )
+        assert len(files) == 1
+        assert path == pathlib.PurePosixPath("test.txt")
+        assert stat["type"] == "file"
+
+
+@pytest.mark.asyncio
 async def test_resolving_double_dots(pair_factory):
     async with pair_factory() as pair:
         await pair.make_server_files("test.txt")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

When using this library in the wild, I came across an ftp server that times out when attempting to start an `epsv` connection. Because it doesn't return an error code, the client never attempts to switch to regular `pasv`.

This PR allows you to specify the commands with which it will attempt to establish a passive connection to the server in the `list` method itself, and they are then passed down to the `get_passive_connection` method.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

Everything is backwards compatible, but it allows the future user to specify which commands to use to establish a passive connection.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
