### PR TITLE
client: add default client-wide passive commands

### DIFF
--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -1098,7 +1098,6 @@ class Client(BaseClient):
             commands = self._passive_commands
         if not commands:
             raise ValueError("No passive commands provided")
-
         await self.command("TYPE " + conn_type, "200")
         for i, name in enumerate(commands, start=1):
             name = name.lower()

--- a/history.rst
+++ b/history.rst
@@ -3,6 +3,7 @@ x.x.x (xx-xx-xxxx)
 
 - client: strip date before parsing (#113)
 - client: logger no longer prints out plaintext password
+- client: add custom passive commands to client
 Thanks to `ndhansen <https://github.com/ndhansen>`_
 
 0.16.0 (11-03-2020)

--- a/history.rst
+++ b/history.rst
@@ -2,8 +2,8 @@ x.x.x (xx-xx-xxxx)
 ------------------
 
 - client: strip date before parsing (#113)
-- client: logger no longer prints out plaintext password
-- client: add custom passive commands to client
+- client: logger no longer prints out plaintext password (#114)
+- client: add custom passive commands to client (#116)
 Thanks to `ndhansen <https://github.com/ndhansen>`_
 
 0.16.0 (11-03-2020)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -43,7 +43,10 @@ async def test_type_success(pair_factory, expect_codes_in_exception):
 async def test_custom_passive_commands(pair_factory):
     async with pair_factory(host="127.0.0.1") as pair:
         pair.client._passive_commands = None
-        await pair.client.get_passive_connection("A", commands=["pasv", "epsv"])
+        await pair.client.get_passive_connection(
+            "A",
+            commands=["pasv", "epsv"]
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -40,6 +40,13 @@ async def test_type_success(pair_factory, expect_codes_in_exception):
 
 
 @pytest.mark.asyncio
+async def test_custom_passive_commands(pair_factory):
+    async with pair_factory(host="127.0.0.1") as pair:
+        pair.client._passive_commands = None
+        await pair.client.get_passive_connection("A", commands=["pasv", "epsv"])
+
+
+@pytest.mark.asyncio
 async def test_extra_pasv_connection(pair_factory):
     async with pair_factory() as pair:
         r, w = await pair.client.get_passive_connection()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -33,6 +33,16 @@ async def test_file_download(pair_factory):
 
 
 @pytest.mark.asyncio
+async def test_file_download_enhanced_passive(pair_factory):
+    async with pair_factory() as pair:
+        pair.client._passive_commands = ["epsv"]
+        await pair.make_server_files("foo", size=1, atom=b"foobar")
+        async with pair.client.download_stream("foo") as stream:
+            data = await stream.read()
+        assert data == b"foobar"
+
+
+@pytest.mark.asyncio
 async def test_file_upload(pair_factory):
     async with pair_factory() as pair:
         async with pair.client.upload_stream("foo") as stream:

--- a/tests/test_passive.py
+++ b/tests/test_passive.py
@@ -42,7 +42,7 @@ async def test_client_only_enhanced_passive_list(pair_factory):
 @pytest.mark.asyncio
 async def test_passive_no_choices(pair_factory):
     async with pair_factory() as pair:
-        pair.client._passive_commands = tuple()
+        pair.client._passive_commands = []
         with pytest.raises(ValueError):
             await pair.client.get_passive_connection(commands=[])
 

--- a/tests/test_passive.py
+++ b/tests/test_passive.py
@@ -20,11 +20,29 @@ async def test_client_fail_fallback_to_pasv_at_list(pair_factory,
         pair.server.commands_mapping["epsv"] = not_implemented
         with expect_codes_in_exception("502"):
             await pair.client.get_passive_connection(commands=["epsv"])
+        with expect_codes_in_exception("502"):
+            pair.client._passive_commands = ["epsv"]
+            await pair.client.get_passive_connection()
+
+
+@pytest.mark.asyncio
+async def test_client_only_passive_list(pair_factory):
+    async with pair_factory(host="127.0.0.1") as pair:
+        pair.client._passive_commands = ["pasv"]
+        await pair.client.list()
+
+
+@pytest.mark.asyncio
+async def test_client_only_enhanced_passive_list(pair_factory):
+    async with pair_factory(host="127.0.0.1") as pair:
+        pair.client._passive_commands = ["epsv"]
+        await pair.client.list()
 
 
 @pytest.mark.asyncio
 async def test_passive_no_choices(pair_factory):
     async with pair_factory() as pair:
+        pair.client._passive_commands = tuple()
         with pytest.raises(ValueError):
             await pair.client.get_passive_connection(commands=[])
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

When using this library in the wild, I came across an ftp server that times out when attempting to start an epsv connection. Because it doesn't return an error code, the client never attempts to switch to regular pasv.

This change lets you pass default passive commands at creation of the client, and if no custom commands are used when creating the passive connection, these will be used. This means it is now possible for you to set client-wide passive commands which will be used whenever a method calls `get_passive_connection`.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

If for some weird reason you were calling `get_passive_connection` with an empty list of commands, it will no longer result in a `ValueError`, because the default client passive commands will be used. But I have no idea why anyone would *ever* do that.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
