### PR TITLE
pathio: update expected exceptions list from unlink on directory (fixes #117)

### DIFF
--- a/history.rst
+++ b/history.rst
@@ -2,6 +2,7 @@ x.x.x (xx-xx-xxxx)
 ------------------
 
 - tests: fix test_unlink_on_dir on POSIX compatible systems (#118)
+Thanks to `AMDmi3 <https://github.com/AMDmi3>`_
 
 0.16.1 (09-07-2020)
 ------------------

--- a/history.rst
+++ b/history.rst
@@ -1,6 +1,8 @@
 x.x.x (xx-xx-xxxx)
 ------------------
 
+- tests: fix test_unlink_on_dir on POSIX compatible systems (#118)
+
 0.16.1 (09-07-2020)
 ------------------
 

--- a/tests/test_pathio.py
+++ b/tests/test_pathio.py
@@ -252,7 +252,7 @@ async def test_unlink_not_exist(path_io, temp_dir):
 
 @pytest.mark.asyncio
 async def test_unlink_on_dir(path_io, temp_dir):
-    with universal_exception_reason(IsADirectoryError):
+    with universal_exception_reason(IsADirectoryError, PermissionError):
         await path_io.unlink(temp_dir)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix `test_unlink_on_dir on POSIX-compatible` systems.

POSIX prescribes ([1]) `unlink(2)` to return EPERM when called on directories:

```
[EPERM]
    The file named by path is a directory, and either the calling process does not have appropriate privileges, or the implementation prohibits using unlink() on directories.
```

and returning `EISDIR` in this case is Linux-specific behavior which does not happen on e.g. FreeBSD. So expect either of IsADirectoryError, PermissionError in the corresponding test.

[1] https://pubs.opengroup.org/onlinepubs/007904975/toc.htm

## Related issue number

#117

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
