### PR TITLE
fix deprecation warning "explicit passing of coroutine objects to asyncio.wait()"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,9 +124,9 @@ Client example
 
 
     tasks = (
-        get_mp3("server1.com", 21, "login", "password"),
-        get_mp3("server2.com", 21, "login", "password"),
-        get_mp3("server3.com", 21, "login", "password"),
+        asyncio.create_task(get_mp3("server1.com", 21, "login", "password")),
+        asyncio.create_task(get_mp3("server2.com", 21, "login", "password")),
+        asyncio.create_task(get_mp3("server3.com", 21, "login", "password")),
     )
     asyncio.run(asyncio.wait(tasks))
 

--- a/aioftp/common.py
+++ b/aioftp/common.py
@@ -473,13 +473,13 @@ class ThrottleStreamIO(StreamIO):
         :param name: name of throttle to acquire ("read" or "write")
         :type name: :py:class:`str`
         """
-        waiters = []
+        tasks = []
         for throttle in self.throttles.values():
             curr_throttle = getattr(throttle, name)
             if curr_throttle.limit:
-                waiters.append(curr_throttle.wait())
-        if waiters:
-            await asyncio.wait(waiters)
+                tasks.append(asyncio.create_task(curr_throttle.wait()))
+        if tasks:
+            await asyncio.wait(tasks)
 
     def append(self, name, data, start):
         """

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -108,9 +108,9 @@ Client example
 
 
     tasks = (
-        get_mp3("server1.com", 21, "login", "password"),
-        get_mp3("server2.com", 21, "login", "password"),
-        get_mp3("server3.com", 21, "login", "password"),
+        asyncio.create_task(get_mp3("server1.com", 21, "login", "password")),
+        asyncio.create_task(get_mp3("server2.com", 21, "login", "password")),
+        asyncio.create_task(get_mp3("server3.com", 21, "login", "password")),
     )
     asyncio.run(asyncio.wait(tasks))
 


### PR DESCRIPTION
## What do these changes do?

Fix `DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.`

https://docs.python.org/3/library/asyncio-task.html?highlight=wait#asyncio-example-wait-coroutine

## Are there changes in behavior for the user?

Nope.

## Related issue number

No.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
