### PR TITLE
server: fix real directory resolve for windows (fixes #147)

### DIFF
--- a/aioftp/server.py
+++ b/aioftp/server.py
@@ -988,7 +988,8 @@ class Server:
             if tasks_to_wait:
                 await asyncio.wait(tasks_to_wait)
 
-    def get_paths(self, connection, path):
+    @staticmethod
+    def get_paths(connection, path):
         """
         Return *real* and *virtual* paths, resolves ".." with "up" action.
         *Real* path is path for path_io, when *virtual* deals with
@@ -1013,11 +1014,13 @@ class Server:
             else:
                 resolved_virtual_path /= part
         base_path = connection.user.base_path
-        real_path = base_path / resolved_virtual_path.relative_to(resolved_virtual_path.anchor)
+        real_path = base_path / resolved_virtual_path.relative_to("/")
+        # replace with `is_relative_to` check after 3.9+ requirements lands
         try:
-            resolved_virtual_path = pathlib.PurePosixPath("/") / real_path.relative_to(base_path)
+            real_path.relative_to(base_path)
         except ValueError:
-            return base_path, pathlib.PurePosixPath("/")
+            real_path = base_path
+            resolved_virtual_path = pathlib.PurePosixPath("/")
         return real_path, resolved_virtual_path
 
     async def greeting(self, connection, rest):

--- a/aioftp/server.py
+++ b/aioftp/server.py
@@ -1013,7 +1013,11 @@ class Server:
             else:
                 resolved_virtual_path /= part
         base_path = connection.user.base_path
-        real_path = base_path / resolved_virtual_path.relative_to("/")
+        real_path = base_path / resolved_virtual_path.relative_to(resolved_virtual_path.anchor)
+        try:
+            resolved_virtual_path = pathlib.PurePosixPath("/") / real_path.relative_to(base_path)
+        except ValueError:
+            return base_path, pathlib.PurePosixPath("/")
         return real_path, resolved_virtual_path
 
     async def greeting(self, connection, rest):

--- a/tests/test_simple_functions.py
+++ b/tests/test_simple_functions.py
@@ -230,3 +230,17 @@ def test_server_mtime_build():
     b = aioftp.Server.build_list_mtime
     assert b(now, now) == "Jan  1 00:00"
     assert b(past, now) == "Jan  1  2001"
+
+
+def test_get_paths_windows_traverse():
+    base_path = pathlib.PureWindowsPath("C:\\ftp")
+    user = aioftp.User()
+    user.base_path = base_path
+    connection = aioftp.Connection(current_directory=base_path, user=user)
+    virtual_path = pathlib.PurePosixPath("/foo/C:\\windows")
+    real_path, resolved_virtual_path = aioftp.Server.get_paths(
+        connection,
+        virtual_path,
+    )
+    assert real_path == base_path
+    assert resolved_virtual_path == pathlib.PurePosixPath("/")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Sanitize paths so directory traversal is not possible anymore.

## Are there changes in behavior for the user?

Only for users trying to exploit directory traversal. It will send these back to the home directory.

## Related issue number

https://github.com/aio-libs/aioftp/issues/147

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
