### PR TITLE
server: support PASV response with custom address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: build
-on: push
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
This allows old FTP client to connect to AIOFtp server located behind
NAT.

<!-- Thank you for your contribution! -->

## What do these changes do?

The change adds support for clients using passive connections (PASV command) to a server located behind NAT

## Are there changes in behavior for the user?

Passive connections can be opened with PASV command to server behind (IPv4) NAT

## Related issue number

N/A

## Checklist

- [x ] I think the code is well written
- [x ] Unit tests for the changes exist
- [x ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder -- **there is no CHANGES folder**
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
