### PR TITLE
Fixed processing files with broken names

### DIFF
--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -555,7 +555,7 @@ class BaseClient:
         :rtype: (:py:class:`pathlib.PurePosixPath`, :py:class:`dict`)
         """
         if isinstance(b, bytes):
-            s = b.decode(encoding=self.encoding)
+            s = b.decode(encoding=self.encoding, errors='replace')
         else:
             s = b
         line = s.rstrip()

--- a/tests/test_parse_mlsx_line.py
+++ b/tests/test_parse_mlsx_line.py
@@ -1,0 +1,12 @@
+from pathlib import PurePosixPath
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_client_list_broken_file_name(pair_factory):
+    input_bytes = b"type=file;size=1;modify=19700101000000; doc_\xd3\xc2\xd2.txt\r\n"
+    expected = (PurePosixPath('doc_���.txt'), {'modify': '19700101000000', 'size': '1', 'type': 'file'})
+    async with pair_factory() as pair:
+        result = pair.client.parse_mlsx_line(input_bytes)
+        assert result == expected


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This is a small fix to process files with broken names

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

If there is any file with broken name in the FTP-server it will be processed and non-decodable symbols will be replaced.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
