### PR TITLE
adjust codebase for python 3.14

### DIFF
--- a/src/aioftp/client.py
+++ b/src/aioftp/client.py
@@ -423,8 +423,7 @@ class BaseClient:
                     if diff > TWO_YEARS_IN_SECONDS:
                         d = d.replace(year=prev_leap_year + 4)
                 else:
-                    d = datetime.datetime.strptime(s, "%b %d %H:%M")
-                    d = d.replace(year=now.year)
+                    d = datetime.datetime.strptime(f"{now.year} {s}", "%Y %b %d %H:%M")
                     diff = (now - d).total_seconds()
                     if diff > HALF_OF_YEAR_IN_SECONDS:
                         d = d.replace(year=now.year + 1)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -241,7 +241,7 @@ async def test_stat_when_no_mlst(pair_factory):
 @pytest.mark.asyncio
 async def test_stat_mlst(pair_factory):
     async with pair_factory() as pair:
-        now = dt.datetime.utcnow()
+        now = dt.datetime.now(tz=dt.timezone.utc).replace(tzinfo=None)
         await pair.make_server_files("foo")
         info = await pair.client.stat("foo")
         assert info["type"] == "file"

--- a/tests/test_simple_functions.py
+++ b/tests/test_simple_functions.py
@@ -14,14 +14,16 @@ def test_parse_directory_response():
     assert parsed == pathlib.PurePosixPath('baz " test nop')
 
 
-def test_connection_del_future():
+@pytest.mark.asyncio
+async def test_connection_del_future():
     loop = asyncio.new_event_loop()
     c = aioftp.Connection(loop=loop)
     c.foo = "bar"
     del c.future.foo
 
 
-def test_connection_not_in_storage():
+@pytest.mark.asyncio
+async def test_connection_not_in_storage():
     loop = asyncio.new_event_loop()
     c = aioftp.Connection(loop=loop)
     with pytest.raises(AttributeError):
@@ -244,7 +246,8 @@ def test_server_mtime_build():
     assert b(past, now) == "Jan  1  2001"
 
 
-def test_get_paths_windows_traverse():
+@pytest.mark.asyncio
+async def test_get_paths_windows_traverse():
     base_path = pathlib.PureWindowsPath("C:\\ftp")
     user = aioftp.User()
     user.base_path = base_path


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Make `test_simple_functions` tests pass on 3.14
Remove all DeprecationWarnings from pytest runs

<!-- Please give a short brief about these changes. -->

Nothing changed for user

<!-- Outline any notable behavior for the end users. -->

## Related issue number

Fixes #189

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
