### PR TITLE
fix CRLF injection in aioftp client

### DIFF
--- a/src/aioftp/client.py
+++ b/src/aioftp/client.py
@@ -380,6 +380,8 @@ class BaseClient:
         expected_codes = wrap_into_codes(wrap_with_container(expected_codes))
         wait_codes = wrap_into_codes(wrap_with_container(wait_codes))
         if command:
+            if "\r" in command or "\n" in command:
+                raise errors.InvalidCommand("Command must not contain CR/LF")
             if censor_after:
                 # Censor the user's command
                 raw = command[:censor_after]

--- a/src/aioftp/errors.py
+++ b/src/aioftp/errors.py
@@ -93,3 +93,9 @@ class NoAvailablePort(AIOFTPException, OSError):
     """
     Raised when there is no available data port
     """
+
+
+class InvalidCommand(AIOFTPException, ValueError):
+    """
+    Raised when command contains illegal characters
+    """

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -41,3 +41,10 @@ async def test_syst_command(pair_factory):
     async with pair_factory() as pair:
         code, info = await pair.client.command("syst", "215")
         assert info == [" UNIX Type: L8"]
+
+
+@pytest.mark.asyncio
+async def test_illegal_command(pair_factory):
+    async with pair_factory() as pair:
+        with pytest.raises(aioftp.errors.InvalidCommand):
+            await pair.client.command("LIST\r\nfoo")


### PR DESCRIPTION
## What do these changes do?

This pr uses patch from [stdlib](https://github.com/python/cpython/blob/180b3eb697bf5bb0088f3f35ef2d3675f9fff04f/Lib/ftplib.py#L196-L197). It makes aioftp client raise errors if commands contain illegal newline characters (CR/LF) to prevent injection.

## Are there changes in behavior for the user?

Clients won't be affected unless they have CR/LF in username or password, which is not likely to happen.

## Related issue number

Fixes #194 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
