### PR TITLE
fix year assumption in client list command

### DIFF
--- a/src/aioftp/client.py
+++ b/src/aioftp/client.py
@@ -27,7 +27,6 @@ from .common import (
     DEFAULT_PORT,
     DEFAULT_USER,
     END_OF_LINE,
-    HALF_OF_YEAR_IN_SECONDS,
     TWO_YEARS_IN_SECONDS,
     AbstractAsyncLister,
     AsyncEnterableInstanceProtocol,
@@ -543,10 +542,8 @@ class BaseClient:
                         d = d.replace(year=prev_leap_year + 4)
                 else:
                     d = datetime.strptime(f"{now.year} {s}", "%Y %b %d %H:%M")
-                    diff = (now - d).total_seconds()
-                    if diff > HALF_OF_YEAR_IN_SECONDS:
-                        d = d.replace(year=now.year + 1)
-                    elif diff < -HALF_OF_YEAR_IN_SECONDS:
+                    # If the date would be in the future, use previous year instead
+                    if d > now:
                         d = d.replace(year=now.year - 1)
             except ValueError:
                 d = datetime.strptime(s, "%b %d  %Y")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes an issue in the `parse_ls_date function` where dates more than half a year in the past were incorrectly showing up with next year's date.

The original code was using `HALF_OF_YEAR_IN_SECONDS` to determine if a date should be adjusted to the next year, which caused January dates to incorrectly show up as 2026 instead of 2025 when the current date is in August 2025.

The fix:
1. Removes the dependency on `HALF_OF_YEAR_IN_SECONDS`
2. Changes the date parsing logic to use the current year by default
3. Only adjusts the year to the previous year if the resulting date would be 
   in the future

This ensures dates are correctly interpreted regardless of how far in the past they are, fixing timestamp issues in LIST command responses.

## Are there changes in behavior for the user?

No.

## Related issue number
Fixes #196

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
